### PR TITLE
fix: circular type error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for cf-prefs
 // Project: cf-prefs
 
-export type CFPrefValue = boolean | number | string | Array<CFPrefValue> | Record<string, CFPrefValue> | undefined;
+export type CFPrefValue = boolean | string | number | { [key: string]: CFPrefValue } | Array<CFPrefValue>;
 export function getPreferenceValue(key: string): CFPrefValue;
 
 export function isPreferenceForced(key: string): boolean;


### PR DESCRIPTION
Fix for the following error:
```
node_modules/cf-prefs/index.d.ts(4,13): error TS2456: Type alias 'CFPrefValue' circularly references itself.
```